### PR TITLE
Update spotify apt install instructions

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -49,7 +49,7 @@ Apps installed from Snap **cannot be modified** so you need to follow these step
 1. Uninstall Spotify in Snap or run command `snap remove spotify`
 3. Install Spotify using `apt`:
 ```sh
-curl -sS https://download.spotify.com/debian/pubkey_0D811D58.gpg | sudo apt-key add - 
+curl -sS https://download.spotify.com/debian/pubkey_5E3C45D7B312C643.gpg | sudo apt-key add - 
 echo "deb http://repository.spotify.com stable non-free" | sudo tee /etc/apt/sources.list.d/spotify.list
 sudo apt-get update && sudo apt-get install spotify-client
 ```


### PR DESCRIPTION
Source: [Offical Spotify installation instructions](https://www.spotify.com/us/download/linux/#:~:text=the%20command%20above.-,Debian%20/%20Ubuntu,-Spotify%20for%20Linux)
Looks like the GPG key changed.