### PR TITLE
docs: simplify installation process

### DIFF
--- a/docs/getting-started/advanced-installation.md
+++ b/docs/getting-started/advanced-installation.md
@@ -1,42 +1,56 @@
 ---
-title: Installation
-sidebar_position: 1
+title: Advanced Installation
+sidebar_position: 2
 ---
 
 ## Windows
+
 ### Powershell (pre-built binary) - Recommended
+
 ```powershell
 Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/khanhas/spicetify-cli/master/install.ps1" | Invoke-Expression
 ```
+
 If you have problem with downloading, use this:
+
 ```powershell
 Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/khanhas/spicetify-cli/master/install_curl.ps1" | Invoke-Expression
 ```
+
 ### Scoop
+
 Follow this guide: https://github.com/TheRandomLabs/Scoop-Spotify
 
 ### Chocolatey
+
 Follow this guide: https://chocolatey.org/packages/spicetify-cli
 
 ## Linux and MacOS
+
 ### Shell (pre-built binary) - Recommended
+
 ```bash
 curl -fsSL https://raw.githubusercontent.com/khanhas/spicetify-cli/master/install.sh | sh
 ```
 
 ### Homebrew or LinuxBrew
+
 ```bash
 brew install khanhas/tap/spicetify-cli
 ```
 
 ### AUR
+
 ```bash
 yay -S spicetify-cli
 ```
 
 ### Note for Linux users
+
 #### Spotify installed from AUR
+
 Before applying Spicetify, you need to gain write permission on Spotify files, by running command:
+
 ```bash
 sudo chmod a+wr /opt/spotify
 sudo chmod a+wr /opt/spotify/Apps -R
@@ -44,16 +58,21 @@ sudo chmod a+wr /opt/spotify/Apps -R
 
 **Note:** Your Spotify client location might be different.
 
-#### Spotify installed from Snap 
+#### Spotify installed from Snap
+
 Apps installed from Snap **cannot be modified** so you need to follow these steps to get Spicetify working:
+
 1. Uninstall Spotify in Snap or run command `snap remove spotify`
-3. Install Spotify using `apt`:
+2. Install Spotify using `apt`:
+
 ```sh
-curl -sS https://download.spotify.com/debian/pubkey_5E3C45D7B312C643.gpg | sudo apt-key add - 
+curl -sS https://download.spotify.com/debian/pubkey_5E3C45D7B312C643.gpg | sudo apt-key add -
 echo "deb http://repository.spotify.com stable non-free" | sudo tee /etc/apt/sources.list.d/spotify.list
 sudo apt-get update && sudo apt-get install spotify-client
 ```
+
 4. After Spotify is installed successfully, you need to gain read write permissions on Spotify files, by running commands:
+
 ```bash
 sudo chmod a+wr /usr/share/spotify
 sudo chmod a+wr /usr/share/spotify/Apps -R
@@ -62,24 +81,29 @@ sudo chmod a+wr /usr/share/spotify/Apps -R
 **Note:** Your Spotify client location might be different.
 
 #### Spotify installed from Flatpak
+
 - You need to find where Flatpak stores your Spotify client. In Manjaro, it is stored in:
+
 ```
 /var/lib/flatpak/app/com.spotify.Client/x86_64/stable/active/files/extra/share/spotify/
 ```
+
 - Yours might be different, try these steps:
+
 1. Find flatpak installation place with command: `flatpak --installations`
-2. Go to that directory and dig in until you find folder which contain items like these:  
+2. Go to that directory and dig in until you find folder which contain items like these:
 
 ![flat2](https://user-images.githubusercontent.com/26436809/57563050-81408780-73dc-11e9-92e8-d0cc60502ff3.png)
-  
-After you have Spotify location, set `spotify_path` in config file to that directory:  
-  
+
+After you have Spotify location, set `spotify_path` in config file to that directory:
+
 ![flat2](https://user-images.githubusercontent.com/26436809/57563057-9ddcbf80-73dc-11e9-82d8-d31cdf7e9cef.png)
-  
+
 3. Find your `prefs` file:
-It could be either in these two locations:
+   It could be either in these two locations:
+
 - `~/.config/spotify/prefs`
-- `~/.var/app/com.spotify.Client/config/spotify/prefs`  
+- `~/.var/app/com.spotify.Client/config/spotify/prefs`
 
 Check both, expand the right one to absolute path and set it to `prefs_path` in config file.
 
@@ -88,6 +112,7 @@ spicetify config prefs_path ~/.var/app/com.spotify.Client/config/spotify/prefs
 ```
 
 4. Finally in terminal, set read/write permission for it:
+
 ```bash
 sudo chmod a+wr /var/lib/flatpak/app/com.spotify.Client/x86_64/stable/active/files/extra/share/spotify
 sudo chmod a+wr -R /var/lib/flatpak/app/com.spotify.Client/x86_64/stable/active/files/extra/share/spotify/Apps
@@ -95,18 +120,20 @@ sudo chmod a+wr -R /var/lib/flatpak/app/com.spotify.Client/x86_64/stable/active/
 
 ## Legacy Installations
 
-If, for some reason, you are not using the most up to date Spotify client, you may need to install a specific version of Spicetify. 
+If, for some reason, you are not using the most up to date Spotify client, you may need to install a specific version of Spicetify.
 This is not recommended as our prime focus will always be the latest Spotify version.
 
 As such, you will need to run either of the below commands with the desired version.
 If you wish to use old Spotify client v1.1.56 or older, you have to install spicetify v1.2.1.
 
 **Windows**: In powershell
+
 ```powershell
 $v="1.2.1"; Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/khanhas/spicetify-cli/master/install.ps1" | Invoke-Expression
 ```
 
 **Linux/MacOS:** In bash
+
 ```bash
 curl -fsSL https://raw.githubusercontent.com/khanhas/spicetify-cli/master/install.sh -o /tmp/install.sh
 sh /tmp/install.sh 1.2.1

--- a/docs/getting-started/basic-usage.md
+++ b/docs/getting-started/basic-usage.md
@@ -1,6 +1,6 @@
 ---
 title: Basic Usage
-sidebar_position: 2
+sidebar_position: 3
 ---
 
 Run with no command once to generate config file

--- a/docs/getting-started/custom-apps.md
+++ b/docs/getting-started/custom-apps.md
@@ -1,6 +1,6 @@
 ---
 title: Custom Apps
-sidebar_position: 5
+sidebar_position: 6
 ---
 
 Inject custom apps to Spotify and access them in left sidebar.  

--- a/docs/getting-started/extensions.md
+++ b/docs/getting-started/extensions.md
@@ -1,6 +1,6 @@
 ---
 title: Extensions
-sidebar_position: 4
+sidebar_position: 5
 ---
 
 Extensions, in a nutshell, are JavaScript files that will be evaluated along with Spotify main JavaScript.

--- a/docs/getting-started/simple-installation.md
+++ b/docs/getting-started/simple-installation.md
@@ -5,7 +5,7 @@ sidebar_position: 1
 
 ## Windows
 
-This is the installation method what we recommend for most users. It is the fastest and most reliable way to install Spicetify. It also includes the **Spicetify Marketplace** that gives you access to a tab in Spotify's sidebar that allows you to search for and install _themes_, _extensions_ and _snippets_.
+This is the installation method what we recommend for most users. It is the fastest and most reliable way to install Spicetify. It also includes the [**Spicetify Marketplace**](https://github.com/CharlieS1103/spicetify-marketplace) that gives you access to a tab in Spotify's sidebar that allows you to search for and install _themes_, _extensions_ and _snippets_.
 
 ### Powershell (pre-built binary)
 

--- a/docs/getting-started/simple-installation.md
+++ b/docs/getting-started/simple-installation.md
@@ -1,0 +1,30 @@
+---
+title: Simple Installation
+sidebar_position: 1
+---
+
+## Windows
+
+This is the installation method what we recommend for most users. It is the fastest and most reliable way to install Spicetify. It also includes the **Spicetify Marketplace** that gives you access to a tab in Spotify's sidebar that allows you to search for and install _themes_, _extensions_ and _snippets_.
+
+### Powershell (pre-built binary) - Recommended
+
+```powershell
+Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/khanhas/spicetify-cli/master/install.ps1" | Invoke-Expression
+Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/CharlieS1103/spicetify-marketplace/master/install.ps1" | Invoke-Expression
+```
+
+## Linux and MacOS
+
+### Shell (pre-built binary) - Recommended
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/khanhas/spicetify-cli/master/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/CharlieS1103/spicetify-marketplace/main/install.sh | sh
+```
+
+<hr/>
+
+- ⚠️ Sometimes Spotify upgrades things that break Spicetify.<br/>
+- ⚠️ When this happens we need to update Spicetify, and you may need to run `spicetify upgrade`.<br/>
+- ⚠️ After this command, run `spicetify restore backup apply` to have everything back where it was.

--- a/docs/getting-started/simple-installation.md
+++ b/docs/getting-started/simple-installation.md
@@ -7,7 +7,7 @@ sidebar_position: 1
 
 This is the installation method what we recommend for most users. It is the fastest and most reliable way to install Spicetify. It also includes the **Spicetify Marketplace** that gives you access to a tab in Spotify's sidebar that allows you to search for and install _themes_, _extensions_ and _snippets_.
 
-### Powershell (pre-built binary) - Recommended
+### Powershell (pre-built binary)
 
 ```powershell
 Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/khanhas/spicetify-cli/master/install.ps1" | Invoke-Expression
@@ -16,7 +16,7 @@ Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/CharlieS11
 
 ## Linux and MacOS
 
-### Shell (pre-built binary) - Recommended
+### Shell (pre-built binary)
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/khanhas/spicetify-cli/master/install.sh | sh

--- a/docs/getting-started/themes.md
+++ b/docs/getting-started/themes.md
@@ -1,6 +1,6 @@
 ---
 title: Themes
-sidebar_position: 3
+sidebar_position: 4
 ---
 
 One of the most popular features in Spicetify is theming.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -52,7 +52,7 @@ const config = {
         items: [
           {
             type: 'doc',
-            docId: 'getting-started/installation',
+            docId: 'getting-started/simple-installation',
             position: 'left',
             label: 'Docs',
           },
@@ -72,7 +72,7 @@ const config = {
             items: [
               {
                 label: 'Getting Started',
-                to: '/docs/getting-started/installation',
+                to: '/docs/getting-started/simple-installation',
               },
               {
                 label: 'Development',

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -16,7 +16,7 @@ function HomepageHeader() {
         <h1 className="hero__title">{siteConfig.title}</h1>
         <p className="hero__subtitle">{siteConfig.tagline}</p>
         <div className={styles.buttons}>
-          <Link className="button button--secondary button--lg" to="/docs/getting-started/installation">
+          <Link className="button button--secondary button--lg" to="/docs/getting-started/simple-installation">
             Install Now!
           </Link>
         </div>


### PR DESCRIPTION
Closes #12. One thing that I've always had a trouble with was the installation page.

From now on, most people will only need to see this single page, which I think will be a big improvement.

I have, however, already included the Spicetify Marketplace, so I'd like your approval @CharlieS1103 @khanhas @theRealPadster. You can review the change on the Preview page that Vercel will compile.